### PR TITLE
feat: Allow merging multiple payloads for a single type

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,28 @@ type Union = First | Second;
 */
 ```
 
+## Merge multiple payload for the same type
+
+It is possible to provide multiple paylaods for a single type you want to generate. In this case, the payloads will be merged together and optional properties will be infered from them.
+
+```js
+const payloads = {
+  First: [
+    // notice the array for the type First
+    { type: "first", name: "felix", age: 10 },
+    { type: "first", name: "sam" },
+  ],
+  Second: { type: "second", value: "tough" },
+};
+
+const types = generateUnion(payloads);
+/*
+type First = { type: "first", name: string, age?: number };
+type Second = { type: "second", value: string };
+type Union = First | Second;
+*/
+```
+
 ## Extract common properties to a Base type
 
 You might want to extact properties that are common between all the types. In this case you can pass `{ extractCommon: true }` option to the `generateUnion` function

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,50 +1,69 @@
-import { TypeDef, Types } from "./types";
+import { Property, Type } from "./types";
 
-function createTypeScriptDef(type: TypeDef): string {
-  const properties = Object.entries(type)
-    .map(([key, value]) => {
-      const type =
-        typeof value.$$type === "object"
-          ? `{${createTypeScriptDef(value.$$type)}}`
-          : value.$$type;
-
-      return `${key}: ${type}`;
-    })
+function propertiesToType(
+  properties: Property[],
+  discriminant?: string
+): string {
+  return properties
+    .map((type) => propertyToType(type, type.name === discriminant))
     .join(";");
-  return properties;
 }
+
+function propertyToType(propety: Property, keepValue?: boolean): string {
+  const types = new Set(
+    propety.values.map((value) => {
+      if (keepValue) {
+        return JSON.stringify(value);
+      }
+      if (Array.isArray(value)) {
+        return "any[]";
+      }
+      if (typeof value === "object" && value) {
+        const nestedType = propertiesToType(
+          Object.entries(value).map(([name, value]) => ({
+            name,
+            values: [value],
+          }))
+        );
+        return `{${nestedType}}`;
+      }
+      return typeof value;
+    })
+  );
+
+  const isOptional = types.has("undefined");
+  types.delete("undefined");
+  return `${propety.name}${isOptional ? "?" : ""}: ${Array.from(types).join(
+    "|"
+  )}`;
+}
+
+function createTypeScriptDef(type: Type, discriminant?: string): string {
+  const extend = type.extend ? `${type.extend} &` : "";
+  const properties = propertiesToType(type.properties, discriminant);
+
+  return `type ${type.name} = ${extend} { ${properties} }`;
+}
+
 export function renderTypeScript({
+  discriminant,
   base,
   types,
 }: {
-  base?: TypeDef;
-  types: Types;
+  discriminant?: string;
+  base?: Type;
+  types: Type[];
 }) {
-  const typeDefs = Object.entries(types).map(([name, type]) => ({
-    name,
-    extend: base ? "Base" : undefined,
-    props: createTypeScriptDef(type.def),
-  }));
+  const baseType = base ? [createTypeScriptDef(base)] : [];
 
-  const baseType = base
-    ? [
-        {
-          name: "Base",
-          extend: undefined,
-          props: createTypeScriptDef(base),
-        },
-      ]
-    : [];
+  const otherTypes = types.map((type) =>
+    createTypeScriptDef(type, discriminant)
+  );
 
-  const rawTypescript = `
-    ${[...baseType, ...typeDefs]
-      .map(
-        ({ name, extend, props }) =>
-          `type ${name} = ${extend ? `${extend} & ` : ""}{ ${props} }`
-      )
-      .join(";")}
-    type Union = ${typeDefs.map(({ name }) => `${name}`).join("|")}
-  `;
+  const union =
+    types.length > 1
+      ? `type Union = ${types.map(({ name }) => name).join("|")}`
+      : "";
 
-  return rawTypescript;
+  return [...baseType, ...otherTypes, union].join(";\n");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,5 @@
-export type TypeEntry = { $$type: string | number | TypeDef };
-export type TypeDef = Record<string, TypeEntry>;
-export type Types = Record<string, { extends?: string; def: TypeDef }>;
+export type Property = { name: string; values: unknown[] };
+export type Type = { name: string; extend?: string; properties: Property[] };
 
 export type Entry = { [key: string]: unknown };
-export type NamedEntries = Record<string, Entry>;
+export type NamedEntries = Record<string, Entry | Entry[]>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "target": "es2017",
     "declaration": true,
     "strict": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "lib": ["es2020"]
   },
   "files": ["src/index.ts", "src/renderer.ts", "src/generator.ts"],
 }


### PR DESCRIPTION
This will allow merging payloads together and generates union types for those payloads

```js
{
   First: [
      { type: "first", value: 1, first: 1 },
      { type: "first", value: 2 },
   ],
 }
```

Will generate

```ts
type First = {type: "first", value: number, first?: number}
                                          // ^ first has been automatically infered optional
```